### PR TITLE
Edit .travis.yml to enable builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ matrix:
 
 install:
   - composer install --no-dev
-  - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: php
+
 php:
-- '7.2'
-- '7.1' 
-- '7.0'
-- '5.6'
-- '5.3'
-before_script:
-  - composer self-update
-  - composer install
-script: phpunit
+  - '7.2'
+  - '7.1'
+  - '7.0'
+  - '5.6'
+
+matrix:
+  include:
+    - php: '5.3'
+      dist: precise
+
+install:
+  - composer install --no-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ matrix:
 
 install:
   - composer install --no-dev
+  - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ php:
 - '7.0'
 - '5.6'
 - '5.3'
-script: phpunit
-before_install:
+before_script:
   - composer self-update
-install: composer install
-  on:
-    branch: master
-    php: '7.2'
+  - composer install
+script: phpunit

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="./vendor/autoload.php"
+         bootstrap="./test/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/src/Unidays/tracking-client.php
+++ b/src/Unidays/tracking-client.php
@@ -18,7 +18,7 @@ class TrackingClient
     private $key;
     private $tracking;
 
-    function __construct(DirectTrackingDetails $DirectTrackingDetails, $key, bool $test = false)
+    function __construct(DirectTrackingDetails $DirectTrackingDetails, $key, $test = null)
     {
         $this->key = $key;
         $this->tracking = new TrackingHelper($DirectTrackingDetails, $test);

--- a/src/Unidays/tracking-helper.php
+++ b/src/Unidays/tracking-helper.php
@@ -20,7 +20,7 @@ class TrackingHelper
     private $tracking_script_url;
     private $test;
 
-    function __construct(DirectTrackingDetails $directTrackingDetails, bool $test = false)
+    function __construct(DirectTrackingDetails $directTrackingDetails, $test = null)
     {
         $this->directTrackingDetails = $directTrackingDetails;
 
@@ -33,7 +33,7 @@ class TrackingHelper
         if (empty($this->directTrackingDetails->transactionId))
             throw new \InvalidArgumentException('TransactionId is required');
 
-        $this->test = $test;
+        $this->test = isset($test) && is_bool($test) ? $test : false;
 
         $this->tracking_url = 'https://api.myunidays.com/tracking/v1.2/redemption';
         $this->tracking_script_url = $this->tracking_url . '/js';

--- a/test/Unidays/CodelessUrlVerifierTests/WhenConstructingWithAnInvalidKeyTest.php
+++ b/test/Unidays/CodelessUrlVerifierTests/WhenConstructingWithAnInvalidKeyTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenConstructingWithAnInvalidKeyTest extends TestCase
+class WhenConstructingWithAnInvalidKeyTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
@@ -13,12 +11,12 @@ class WhenConstructingWithAnInvalidKeyTest extends TestCase
      *
      * @testWith    [""]
      *              [null]
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Key cannot be null or empty
      */
     public function ThenAnArgumentExceptionIsThrown($key)
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Key cannot be null or empty');
-
-        $ctor = new CodelessUrlVerifier($key);
+        new CodelessUrlVerifier($key);
     }
 }

--- a/test/Unidays/CodelessUrlVerifierTests/WhenConstructingWithAnInvalidKeyTest.php
+++ b/test/Unidays/CodelessUrlVerifierTests/WhenConstructingWithAnInvalidKeyTest.php
@@ -7,10 +7,7 @@ class WhenConstructingWithAnInvalidKeyTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      *
-     * @param $key
-     *
-     * @testWith    [""]
-     *              [null]
+     * @dataProvider invalidInputs
      *
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Key cannot be null or empty
@@ -18,5 +15,13 @@ class WhenConstructingWithAnInvalidKeyTest extends \PHPUnit_Framework_TestCase
     public function ThenAnArgumentExceptionIsThrown($key)
     {
         new CodelessUrlVerifier($key);
+    }
+
+    public function invalidInputs()
+    {
+        return array(
+            array(""),
+            array(null)
+        );
     }
 }

--- a/test/Unidays/CodelessUrlVerifierTests/WhenVerifyingAValidHashTest.php
+++ b/test/Unidays/CodelessUrlVerifierTests/WhenVerifyingAValidHashTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenVerifyingAValidHashTest extends TestCase
+class WhenVerifyingAValidHashTest extends \PHPUnit_Framework_TestCase
 {
     private $key;
 

--- a/test/Unidays/CodelessUrlVerifierTests/WhenVerifyingAnInvalidHashTest.php
+++ b/test/Unidays/CodelessUrlVerifierTests/WhenVerifyingAnInvalidHashTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenVerifyingAnInvalidHashTest extends TestCase
+class WhenVerifyingAnInvalidHashTest extends \PHPUnit_Framework_TestCase
 {
     private $key;
 
@@ -43,29 +41,29 @@ class WhenVerifyingAnInvalidHashTest extends TestCase
 
     /**
      * @test
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage URL does not contain the required query parameters
      */
     public function WhenVerifyingAUrlWithStudentMissingAnExceptionIsThrown()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('URL does not contain the required query parameters');
-
         $url = 'https://test.com?ud_t=1420070500&ud_h=qaOotWTdl1GjooDmgagETc4ov8FPo4U7rE5RDp0Gfnmo4UVe5JDQhQYDgi1CXNwYa8xSXE4B0QmM96kqf4DLsw%3D%3D';
 
         $verifier = new CodelessUrlVerifier($this->key);
-        $verified = $verifier->verify_url($url);
+        $verifier->verify_url($url);
     }
 
     /**
      * @test
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage URL does not contain the required query parameters
      */
     public function WhenVerifyingAUrlWithTimeMissingAnExceptionIsThrown()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('URL does not contain the required query parameters');
-
         $url = 'https://test.com?ud_s=eesNa1l1bUWKHsWfOLemXQ%3D%3D&ud_h=qaOotWTdl1GjooDmgagETc4ov8FPo4U7rE5RDp0Gfnmo4UVe5JDQhQYDgi1CXNwYa8xSXE4B0QmM96kqf4DLsw%3D%3D';
 
         $verifier = new CodelessUrlVerifier($this->key);
-        $verified = $verifier->verify_url($url);
+        $verifier->verify_url($url);
     }
 }

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithAnInvalidPartnerIdTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithAnInvalidPartnerIdTest.php
@@ -7,10 +7,7 @@ class WhenConstructingWithAnInvalidPartnerIdTest extends \PHPUnit_Framework_Test
     /**
      * @test
      *
-     * @param $partnerId
-     *
-     * @testWith    [""]
-     *              [null]
+     * @dataProvider invalidInputs
      *
      * @expectedException InvalidArgumentException
      */
@@ -20,5 +17,13 @@ class WhenConstructingWithAnInvalidPartnerIdTest extends \PHPUnit_Framework_Test
         $builtDetails = $details->build();
 
         new TrackingHelper($builtDetails);
+    }
+
+    public function invalidInputs()
+    {
+        return array(
+            array(""),
+            array(null)
+        );
     }
 }

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithAnInvalidPartnerIdTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithAnInvalidPartnerIdTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenConstructingWithAnInvalidPartnerIdTest extends TestCase
+class WhenConstructingWithAnInvalidPartnerIdTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
@@ -13,14 +11,14 @@ class WhenConstructingWithAnInvalidPartnerIdTest extends TestCase
      *
      * @testWith    [""]
      *              [null]
+     *
+     * @expectedException InvalidArgumentException
      */
     public function ThenAnArgumentExceptionIsThrown($partnerId)
     {
-        $this->expectException(\InvalidArgumentException::class);
-
         $details = new DirectTrackingDetailsBuilder($partnerId, "Order123", "GBP");
         $builtDetails = $details->build();
 
-        $ctor = new TrackingHelper($builtDetails);
+        new TrackingHelper($builtDetails);
     }
 }

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithoutACurrencyTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithoutACurrencyTest.php
@@ -7,10 +7,7 @@ class WhenConstructingWithoutACurrencyTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      *
-     * @param $currency
-     *
-     * @testWith    [""]
-     *              [null]
+     * @dataProvider invalidInputs
      *
      * @expectedException InvalidArgumentException
      */
@@ -20,5 +17,13 @@ class WhenConstructingWithoutACurrencyTest extends \PHPUnit_Framework_TestCase
         $builtDetails = $details->build();
 
         new TrackingHelper($builtDetails);
+    }
+
+    public function invalidInputs()
+    {
+        return array(
+            array(""),
+            array(null)
+        );
     }
 }

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithoutACurrencyTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithoutACurrencyTest.php
@@ -2,25 +2,23 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenConstructingWithoutACurrencyTest extends TestCase
+class WhenConstructingWithoutACurrencyTest extends \PHPUnit_Framework_TestCase
 {
     /**
- * @test
- *
- * @param $currency
- *
- * @testWith    [""]
- *              [null]
- */
+     * @test
+     *
+     * @param $currency
+     *
+     * @testWith    [""]
+     *              [null]
+     *
+     * @expectedException InvalidArgumentException
+     */
     public function ThenAnArgumentExceptionIsThrown($currency)
     {
-        $this->expectException(\InvalidArgumentException::class);
-
         $details = new DirectTrackingDetailsBuilder("somePartnerId", "Order123", $currency);
         $builtDetails = $details->build();
 
-        $ctor = new TrackingHelper($builtDetails);
+        new TrackingHelper($builtDetails);
     }
 }

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithoutATransactionIdTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithoutATransactionIdTest.php
@@ -2,25 +2,23 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenConstructingWithoutATransactionIdTest extends TestCase
+class WhenConstructingWithoutATransactionIdTest extends \PHPUnit_Framework_TestCase
 {
     /**
- * @test
- *
- * @param $transactionId
- *
- * @testWith    [""]
- *              [null]
- */
+     * @test
+     *
+     * @param $transactionId
+     *
+     * @testWith    [""]
+     *              [null]
+     *
+     * @expectedException InvalidArgumentException
+     */
     public function ThenAnArgumentExceptionIsThrown($transactionId)
     {
-        $this->expectException(\InvalidArgumentException::class);
-
         $details = new DirectTrackingDetailsBuilder("somePartnerId", $transactionId, "GBP");
         $builtDetails = $details->build();
 
-        $ctor = new TrackingHelper($builtDetails);
+        new TrackingHelper($builtDetails);
     }
 }

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithoutATransactionIdTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithoutATransactionIdTest.php
@@ -7,10 +7,7 @@ class WhenConstructingWithoutATransactionIdTest extends \PHPUnit_Framework_TestC
     /**
      * @test
      *
-     * @param $transactionId
-     *
-     * @testWith    [""]
-     *              [null]
+     * @dataProvider invalidInputs
      *
      * @expectedException InvalidArgumentException
      */
@@ -20,5 +17,13 @@ class WhenConstructingWithoutATransactionIdTest extends \PHPUnit_Framework_TestC
         $builtDetails = $details->build();
 
         new TrackingHelper($builtDetails);
+    }
+
+    public function invalidInputs()
+    {
+        return array(
+            array(""),
+            array(null)
+        );
     }
 }

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithAllParamsSetTest.php
@@ -37,7 +37,7 @@ class WhenRequestingAScriptUrlWithAllParamsSetTest extends \PHPUnit_Framework_Te
     /**
      * @test
      */
-    public function TheHostShouldBeApiMyunidaysCom()
+    public function TheHostShouldBeCorrect()
     {
         $host = parse_url($this->url, PHP_URL_HOST);
         $this->assertEquals('api.myunidays.com', $host);
@@ -46,7 +46,7 @@ class WhenRequestingAScriptUrlWithAllParamsSetTest extends \PHPUnit_Framework_Te
     /**
      * @test
      */
-    public function ThePathShouldBeV1_2RedmeptionJs()
+    public function ThePathShouldBeV1_2RedemptionJs()
     {
         $path = parse_url($this->url, PHP_URL_PATH);
         $this->assertEquals('/tracking/v1.2/redemption/js', $path);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithAllParamsSetTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenRequestingAScriptUrlWithAllParamsSetTest extends TestCase
+class WhenRequestingAScriptUrlWithAllParamsSetTest extends \PHPUnit_Framework_TestCase
 {
     var $url;
 

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithSomeParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithSomeParamsSetTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenRequestingAScriptUrlWithSomeParamsSetTest extends TestCase
+class WhenRequestingAScriptUrlWithSomeParamsSetTest extends \PHPUnit_Framework_TestCase
 {
     var $url;
 

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithSomeParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithSomeParamsSetTest.php
@@ -27,7 +27,7 @@ class WhenRequestingAScriptUrlWithSomeParamsSetTest extends \PHPUnit_Framework_T
     /**
      * @test
      */
-    public function TheHostShouldBeApiMyunidaysCom()
+    public function TheHostShouldBeCorrect()
     {
         $host = parse_url($this->url, PHP_URL_HOST);
         $this->assertEquals('api.myunidays.com', $host);
@@ -36,7 +36,7 @@ class WhenRequestingAScriptUrlWithSomeParamsSetTest extends \PHPUnit_Framework_T
     /**
      * @test
      */
-    public function ThePathShouldBeV1_2RedmeptionJs()
+    public function ThePathShouldBeV1_2RedemptionJs()
     {
         $path = parse_url($this->url, PHP_URL_PATH);
         $this->assertEquals('/tracking/v1.2/redemption/js', $path);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithTestModeSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithTestModeSetTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenRequestingAScriptUrlWithTestModeSetTest extends TestCase
+class WhenRequestingAScriptUrlWithTestModeSetTest extends \PHPUnit_Framework_TestCase
 {
     var $url;
 

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithTestModeSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithTestModeSetTest.php
@@ -37,7 +37,7 @@ class WhenRequestingAScriptUrlWithTestModeSetTest extends \PHPUnit_Framework_Tes
     /**
      * @test
      */
-    public function TheHostShouldBeApiMyunidaysCom()
+    public function TheHostShouldBeCorrect()
     {
         $host = parse_url($this->url, PHP_URL_HOST);
         $this->assertEquals('api.myunidays.com', $host);
@@ -46,7 +46,7 @@ class WhenRequestingAScriptUrlWithTestModeSetTest extends \PHPUnit_Framework_Tes
     /**
      * @test
      */
-    public function ThePathShouldBeV1_2RedmeptionJs()
+    public function ThePathShouldBeV1_2RedemptionJs()
     {
         $path = parse_url($this->url, PHP_URL_PATH);
         $this->assertEquals('/tracking/v1.2/redemption/js', $path);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithAllParamsSetTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenRequestingAServerUrlWithAllParamsSetTest extends TestCase
+class WhenRequestingAServerUrlWithAllParamsSetTest extends \PHPUnit_Framework_TestCase
 {
     var $url;
 

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithAllParamsSetTest.php
@@ -39,7 +39,7 @@ class WhenRequestingAServerUrlWithAllParamsSetTest extends \PHPUnit_Framework_Te
     /**
      * @test
      */
-    public function TheHostShouldBeApiMyunidaysCom()
+    public function TheHostShouldBeCorrect()
     {
         $host = parse_url($this->url, PHP_URL_HOST);
         $this->assertEquals('api.myunidays.com', $host);
@@ -48,7 +48,7 @@ class WhenRequestingAServerUrlWithAllParamsSetTest extends \PHPUnit_Framework_Te
     /**
      * @test
      */
-    public function ThePathShouldBeV1_2Redmeption()
+    public function ThePathShouldBeV1_2Redemption()
     {
         $path = parse_url($this->url, PHP_URL_PATH);
         $this->assertEquals('/tracking/v1.2/redemption', $path);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithSomeParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithSomeParamsSetTest.php
@@ -29,7 +29,7 @@ class WhenRequestingAServerUrlWithSomeParamsSetTest extends \PHPUnit_Framework_T
     /**
      * @test
      */
-    public function TheHostShouldBeApiMyunidaysCom()
+    public function TheHostShouldBeCorrect()
     {
         $host = parse_url($this->url, PHP_URL_HOST);
         $this->assertEquals('api.myunidays.com', $host);
@@ -38,7 +38,7 @@ class WhenRequestingAServerUrlWithSomeParamsSetTest extends \PHPUnit_Framework_T
     /**
      * @test
      */
-    public function ThePathShouldBeV1_2Redmeption()
+    public function ThePathShouldBeV1_2Redemption()
     {
         $path = parse_url($this->url, PHP_URL_PATH);
         $this->assertEquals('/tracking/v1.2/redemption', $path);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithSomeParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithSomeParamsSetTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenRequestingAServerUrlWithSomeParamsSetTest extends TestCase
+class WhenRequestingAServerUrlWithSomeParamsSetTest extends \PHPUnit_Framework_TestCase
 {
     var $url;
 

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithTestModeSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithTestModeSetTest.php
@@ -39,7 +39,7 @@ class WhenRequestingAServerUrlWithTestModeSetTest extends \PHPUnit_Framework_Tes
     /**
      * @test
      */
-    public function TheHostShouldBeApiMyunidaysCom()
+    public function TheHostShouldBeCorrect()
     {
         $host = parse_url($this->url, PHP_URL_HOST);
         $this->assertEquals('api.myunidays.com', $host);
@@ -48,7 +48,7 @@ class WhenRequestingAServerUrlWithTestModeSetTest extends \PHPUnit_Framework_Tes
     /**
      * @test
      */
-    public function ThePathShouldBeV1_2Redmeption()
+    public function ThePathShouldBeV1_2Redemption()
     {
         $path = parse_url($this->url, PHP_URL_PATH);
         $this->assertEquals('/tracking/v1.2/redemption', $path);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithTestModeSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithTestModeSetTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenRequestingAServerUrlWithTestModeSetTest extends TestCase
+class WhenRequestingAServerUrlWithTestModeSetTest extends \PHPUnit_Framework_TestCase
 {
     var $url;
 

--- a/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithAllParamsSetTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenRequestingASignedScriptUrlWithAllParamsSetTest extends TestCase
+class WhenRequestingASignedScriptUrlWithAllParamsSetTest extends \PHPUnit_Framework_TestCase
 {
     var $url;
 

--- a/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithAllParamsSetTest.php
@@ -39,7 +39,7 @@ class WhenRequestingASignedScriptUrlWithAllParamsSetTest extends \PHPUnit_Framew
     /**
      * @test
      */
-    public function TheHostShouldBeApiMyunidaysCom()
+    public function TheHostShouldBeCorrect()
     {
         $host = parse_url($this->url, PHP_URL_HOST);
         $this->assertEquals('api.myunidays.com', $host);
@@ -48,7 +48,7 @@ class WhenRequestingASignedScriptUrlWithAllParamsSetTest extends \PHPUnit_Framew
     /**
      * @test
      */
-    public function ThePathShouldBeV1_2RedmeptionJs()
+    public function ThePathShouldBeV1_2RedemptionJs()
     {
         $path = parse_url($this->url, PHP_URL_PATH);
         $this->assertEquals('/tracking/v1.2/redemption/js', $path);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithTestModeSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithTestModeSetTest.php
@@ -2,9 +2,7 @@
 
 namespace Unidays;
 
-use PHPUnit\Framework\TestCase;
-
-class WhenRequestingASignedScriptUrlWithTestModeSetTest extends TestCase
+class WhenRequestingASignedScriptUrlWithTestModeSetTest extends \PHPUnit_Framework_TestCase
 {
     var $url;
 

--- a/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithTestModeSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithTestModeSetTest.php
@@ -39,7 +39,7 @@ class WhenRequestingASignedScriptUrlWithTestModeSetTest extends \PHPUnit_Framewo
     /**
      * @test
      */
-    public function TheHostShouldBeApiMyunidaysCom()
+    public function TheHostShouldBeCorrect()
     {
         $host = parse_url($this->url, PHP_URL_HOST);
         $this->assertEquals('api.myunidays.com', $host);
@@ -48,7 +48,7 @@ class WhenRequestingASignedScriptUrlWithTestModeSetTest extends \PHPUnit_Framewo
     /**
      * @test
      */
-    public function ThePathShouldBeV1_2RedmeptionJs()
+    public function ThePathShouldBeV1_2RedemptionJs()
     {
         $path = parse_url($this->url, PHP_URL_PATH);
         $this->assertEquals('/tracking/v1.2/redemption/js', $path);

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+require_once(__DIR__ . '/../vendor/autoload.php');
+
+// Backwards compatibility shim to support phpunit >= 6
+if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase'))
+    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');


### PR DESCRIPTION
### Requirements

Need builds for any branches on `unidays-php` to run on [Travis](https://travis-ci.org/MyUNiDAYS/unidays-php/branches).

[JIRA TASK AD-253](https://myunidays.atlassian.net/browse/AD-253) outlines the work that needed doing and the decisions that need to be made for this work to be completed.

### Description of the Change

`composer install` needs to run before `phpunit` and as such, needed to be put into a `before_script:` section in the .travis.yml

### Benefits

For each push to this repository, Travis can indicate if the solution builds and all tests pass against multiple version of php

### Possible Drawbacks

**Some of the packages used in the current implementation requires php ^7.1** 

![image](https://user-images.githubusercontent.com/13496774/44660986-265b3180-aa01-11e8-8d49-76e611c396aa.png)

Here are some examples of the packages not supported:

![image](https://user-images.githubusercontent.com/13496774/44661047-599dc080-aa01-11e8-8cc8-390b6f36b35d.png)

**5.3 uses precise instead of trusty - and therefore cannot be run on Travis**

![image](https://user-images.githubusercontent.com/13496774/44661118-88b43200-aa01-11e8-81cb-fef6096eff8d.png)

### Verification Process

Checked build log on [Travis](https://travis-ci.org/MyUNiDAYS/unidays-php/branches) after pushing changes