### PR TITLE
#16 Don't number format here it's already done on the client. Number …

### DIFF
--- a/src/Unidays/direct-tracking-details-builder.php
+++ b/src/Unidays/direct-tracking-details-builder.php
@@ -31,42 +31,42 @@ class DirectTrackingDetailsBuilder
 
     function withOrderTotal($order_total)
     {
-        $this->direct_tracking_details->orderTotal = number_format($order_total, 2);
+        $this->direct_tracking_details->orderTotal = $order_total;
     }
 
     function withItemsUnidaysDiscount($items_unidays_discount)
     {
-        $this->direct_tracking_details->itemsUnidaysDiscount = number_format($items_unidays_discount, 2);
+        $this->direct_tracking_details->itemsUnidaysDiscount = $items_unidays_discount;
     }
 
     function withItemsTax($items_tax)
     {
-        $this->direct_tracking_details->itemsTax = number_format($items_tax, 2);
+        $this->direct_tracking_details->itemsTax = $items_tax;
     }
 
     function withShippingGross($shipping_gross)
     {
-        $this->direct_tracking_details->shippingGross = number_format($shipping_gross, 2);
+        $this->direct_tracking_details->shippingGross = $shipping_gross;
     }
 
     function withShippingDiscount($shipping_discount)
     {
-        $this->direct_tracking_details->shippingDiscount = number_format($shipping_discount, 2);
+        $this->direct_tracking_details->shippingDiscount = $shipping_discount;
     }
 
     function withItemsGross($items_gross)
     {
-        $this->direct_tracking_details->itemsGross = number_format($items_gross, 2);
+        $this->direct_tracking_details->itemsGross = $items_gross;
     }
 
     function withItemsOtherDiscount($items_other_discount)
     {
-        $this->direct_tracking_details->itemsOtherDiscount = number_format($items_other_discount, 2);
+        $this->direct_tracking_details->itemsOtherDiscount = $items_other_discount;
     }
 
     function withUnidaysDiscountPercentage($unidays_discount_percentage)
     {
-        $this->direct_tracking_details->unidaysDiscountPercentage = number_format($unidays_discount_percentage, 2);
+        $this->direct_tracking_details->unidaysDiscountPercentage = $unidays_discount_percentage;
     }
 
     function withNewCustomer($new_customer)


### PR DESCRIPTION
…formatting twice will throw an error on amounts >999.99 because of the ',' as a thousands separator.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->
Currently number formatting is done twice if you use the `DirectTrackingDetailsBuilder` to build the `DirectTrackingDetails` and afterwards use the `DirectTrackingDetails` to send the request with the `TrackingClient`. This leads to errors/notices when the amount is >= 1,000.00 (because of the thousands separator which can't be parsed).

Removed the number formatting on the `DirectTrackingDetailsBuilder` (which sets the public fields on the `DirectTrackingDetails`). I removed them here because the fields are public anyway and can be changed by anyone.

The `TrackingHelper` will then do the number formatting when generating the URL.



### Benefits

<!-- What benefits will be realized by the code change? -->
* One error/warning/notice less
* Prevent unexpected behaviour
### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Using the `DirectTrackingDetailsBuilder` to build supply details via the `withXY()` methods won't number_format anymore. If you use the `DirectTrackingDetailsBuilder` but NOT the `TrackingHelper` to build the URL and send the request, they won't experience formatting.
### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?
Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Trigger a Unidays Tracking call on an order >999.99 €/$/whatever.

### Applicable Issues

<!-- Enter any applicable Issues here -->
#16 