### PR TITLE
Fixes PHP 7.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 language: php
 php:
-- '7.2'
-- '7.1'
-- '7.0'
-- '5.6'
-matrix:
-  include:
-  - php: '5.3'
-    dist: precise
+    - "7.2"
+    - "7.1"
+    - "7.0"
+    - "5.6"
 install:
-- composer install --no-dev
+    - composer install --no-dev
 notifications:
-  slack:
-    secure: DBrOkXTohMdiU7kZyjL8rXbGSzI1WimlaH/1tk9it2+wM8RkM14qkkOrdcEiBdRGJmoZ2h0KYrCMgTbT/onyAjfm1FIOgSmSkziIskS6N/w95FoNpnpD3SR4cXFAKLo1wtxImsvHXac745rNxLGy24yOqoy8ToBMhsBSdxBNoUyavLtfnWjCdgrsFzTgItztGSHqUbeOHLXhG3FG0Cb91nIoNLNtiQfC1Ut2tj5ALHeqrrd6kvpFxBeljQohZXxVJ1/xMtr/aomX2sMjsTwygcoYBr922wSLOWuR6d7wKd7Xk0BR85Ji5cJEz8HUOk6QdHj3Lr/SR1r9l50FYJ6EXOE0GFkbc039zHHP+i0PgyN4weJtafOqgLJQesTQP8CM17iLsQs3ufSz8uMtajPWMyEbEyrkR0Rr/w1YCGENizlNTn5KAjVcHC5UQatnTYS1w//u4zj65S9mk7QEkKG7Szo+SD1V4BSo+8hH5YBtkETqcad4cKTeGOK5WUeXlVD33aNY5oNY6mrsbGwPGYsYQqv4L+WTHZunKntpU7dpINylMlDG4iUeWghpqPiAnZQnpmcSE1c53iX/nRgjkcnhjFoJcB2LbvgrFtOyMvSMnNWV8cC3b33kFmvaCFMxi6gTv/xRbqqypdT7jhWrBbamojdgvzHxxqmk05ylWtBcDLY=
-    on_success: never
-    on_failure: always
+    slack:
+        secure: DBrOkXTohMdiU7kZyjL8rXbGSzI1WimlaH/1tk9it2+wM8RkM14qkkOrdcEiBdRGJmoZ2h0KYrCMgTbT/onyAjfm1FIOgSmSkziIskS6N/w95FoNpnpD3SR4cXFAKLo1wtxImsvHXac745rNxLGy24yOqoy8ToBMhsBSdxBNoUyavLtfnWjCdgrsFzTgItztGSHqUbeOHLXhG3FG0Cb91nIoNLNtiQfC1Ut2tj5ALHeqrrd6kvpFxBeljQohZXxVJ1/xMtr/aomX2sMjsTwygcoYBr922wSLOWuR6d7wKd7Xk0BR85Ji5cJEz8HUOk6QdHj3Lr/SR1r9l50FYJ6EXOE0GFkbc039zHHP+i0PgyN4weJtafOqgLJQesTQP8CM17iLsQs3ufSz8uMtajPWMyEbEyrkR0Rr/w1YCGENizlNTn5KAjVcHC5UQatnTYS1w//u4zj65S9mk7QEkKG7Szo+SD1V4BSo+8hH5YBtkETqcad4cKTeGOK5WUeXlVD33aNY5oNY6mrsbGwPGYsYQqv4L+WTHZunKntpU7dpINylMlDG4iUeWghpqPiAnZQnpmcSE1c53iX/nRgjkcnhjFoJcB2LbvgrFtOyMvSMnNWV8cC3b33kFmvaCFMxi6gTv/xRbqqypdT7jhWrBbamojdgvzHxxqmk05ylWtBcDLY=
+        on_success: never
+        on_failure: always

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "license": "MIT",
     "require": {
-        "php": ">=5.3",
+        "php": ">=5.6",
         "ext-curl": "*",
         "nategood/httpful": "*"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,8 +4,8 @@
          bootstrap="./test/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
+         convertNoticesToExceptions="false"
+         convertWarningsToExceptions="false"
          processIsolation="false"
          stopOnFailure="false"
 >

--- a/test/Unidays/CodelessUrlVerifierTests/WhenConstructingWithAnInvalidKeyTest.php
+++ b/test/Unidays/CodelessUrlVerifierTests/WhenConstructingWithAnInvalidKeyTest.php
@@ -2,7 +2,7 @@
 
 namespace Unidays;
 
-class WhenConstructingWithAnInvalidKeyTest extends \PHPUnit_Framework_TestCase
+class WhenConstructingWithAnInvalidKeyTest extends TestCaseBase
 {
     /**
      * @test

--- a/test/Unidays/CodelessUrlVerifierTests/WhenConstructingWithAnInvalidKeyTest.php
+++ b/test/Unidays/CodelessUrlVerifierTests/WhenConstructingWithAnInvalidKeyTest.php
@@ -4,16 +4,17 @@ namespace Unidays;
 
 class WhenConstructingWithAnInvalidKeyTest extends TestCaseBase
 {
+
     /**
      * @test
      *
      * @dataProvider invalidInputs
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Key cannot be null or empty
      */
     public function ThenAnArgumentExceptionIsThrown($key)
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Key cannot be null or empty");
+
         new CodelessUrlVerifier($key);
     }
 

--- a/test/Unidays/CodelessUrlVerifierTests/WhenVerifyingAValidHashTest.php
+++ b/test/Unidays/CodelessUrlVerifierTests/WhenVerifyingAValidHashTest.php
@@ -2,11 +2,11 @@
 
 namespace Unidays;
 
-class WhenVerifyingAValidHashTest extends \PHPUnit_Framework_TestCase
+class WhenVerifyingAValidHashTest extends TestCaseBase
 {
     private $key;
 
-    public function setUp()
+    public function initialise()
     {
         $this->key = 'tnFUmqDkq1w9eT65hF9okxL1On+d2BQWUyOFLYE3FTOwHjmnt5Sh/sxMA3/i0od3pV5EBfSAmXo//fjIdAE3cIAatX7ZZqVi0Dr8qEYGtku+ZRVbPSmTcEUTA/gXYo3KyL2JqXaZ/qhUvCMbLWyV07qRiFOjyLdOWhioHlJM5io=';
     }

--- a/test/Unidays/CodelessUrlVerifierTests/WhenVerifyingAnInvalidHashTest.php
+++ b/test/Unidays/CodelessUrlVerifierTests/WhenVerifyingAnInvalidHashTest.php
@@ -2,14 +2,9 @@
 
 namespace Unidays;
 
-class WhenVerifyingAnInvalidHashTest extends \PHPUnit_Framework_TestCase
+class WhenVerifyingAnInvalidHashTest extends TestCaseBase
 {
-    private $key;
-
-    public function setUp()
-    {
-        $this->key = 'tnFUmqDkq1w9eT65hF9okxL1On+d2BQWUyOFLYE3FTOwHjmnt5Sh/sxMA3/i0od3pV5EBfSAmXo//fjIdAE3cIAatX7ZZqVi0Dr8qEYGtku+ZRVbPSmTcEUTA/gXYo3KyL2JqXaZ/qhUvCMbLWyV07qRiFOjyLdOWhioHlJM5io=';
-    }
+    private $key = 'tnFUmqDkq1w9eT65hF9okxL1On+d2BQWUyOFLYE3FTOwHjmnt5Sh/sxMA3/i0od3pV5EBfSAmXo//fjIdAE3cIAatX7ZZqVi0Dr8qEYGtku+ZRVbPSmTcEUTA/gXYo3KyL2JqXaZ/qhUvCMbLWyV07qRiFOjyLdOWhioHlJM5io=';
 
     /**
      * @test

--- a/test/Unidays/CodelessUrlVerifierTests/WhenVerifyingAnInvalidHashTest.php
+++ b/test/Unidays/CodelessUrlVerifierTests/WhenVerifyingAnInvalidHashTest.php
@@ -36,12 +36,12 @@ class WhenVerifyingAnInvalidHashTest extends TestCaseBase
 
     /**
      * @test
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage URL does not contain the required query parameters
      */
     public function WhenVerifyingAUrlWithStudentMissingAnExceptionIsThrown()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("URL does not contain the required query parameters");
+
         $url = 'https://test.com?ud_t=1420070500&ud_h=qaOotWTdl1GjooDmgagETc4ov8FPo4U7rE5RDp0Gfnmo4UVe5JDQhQYDgi1CXNwYa8xSXE4B0QmM96kqf4DLsw%3D%3D';
 
         $verifier = new CodelessUrlVerifier($this->key);
@@ -50,12 +50,12 @@ class WhenVerifyingAnInvalidHashTest extends TestCaseBase
 
     /**
      * @test
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage URL does not contain the required query parameters
      */
     public function WhenVerifyingAUrlWithTimeMissingAnExceptionIsThrown()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("URL does not contain the required query parameters");
+
         $url = 'https://test.com?ud_s=eesNa1l1bUWKHsWfOLemXQ%3D%3D&ud_h=qaOotWTdl1GjooDmgagETc4ov8FPo4U7rE5RDp0Gfnmo4UVe5JDQhQYDgi1CXNwYa8xSXE4B0QmM96kqf4DLsw%3D%3D';
 
         $verifier = new CodelessUrlVerifier($this->key);

--- a/test/Unidays/TestCaseBase.php
+++ b/test/Unidays/TestCaseBase.php
@@ -1,0 +1,14 @@
+<?php
+namespace Unidays;
+
+use \PHPUnit\Framework\TestCase;
+
+abstract class TestCaseBase extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->initialise();
+    }
+
+    protected function initialise() {}
+}

--- a/test/Unidays/TestCaseBase5.php
+++ b/test/Unidays/TestCaseBase5.php
@@ -1,0 +1,16 @@
+<?php
+namespace Unidays;
+
+// Backwards compatibility shim to support phpunit >= 6
+if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase'))
+    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+
+abstract class TestCaseBase extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->initialise();
+    }
+
+    protected function initialise() {}
+}

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithAnInvalidPartnerIdTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithAnInvalidPartnerIdTest.php
@@ -2,7 +2,7 @@
 
 namespace Unidays;
 
-class WhenConstructingWithAnInvalidPartnerIdTest extends \PHPUnit_Framework_TestCase
+class WhenConstructingWithAnInvalidPartnerIdTest extends TestCaseBase
 {
     /**
      * @test

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithAnInvalidPartnerIdTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithAnInvalidPartnerIdTest.php
@@ -8,11 +8,11 @@ class WhenConstructingWithAnInvalidPartnerIdTest extends TestCaseBase
      * @test
      *
      * @dataProvider invalidInputs
-     *
-     * @expectedException InvalidArgumentException
      */
     public function ThenAnArgumentExceptionIsThrown($partnerId)
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $details = new DirectTrackingDetailsBuilder($partnerId, "Order123", "GBP");
         $builtDetails = $details->build();
 

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithoutACurrencyTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithoutACurrencyTest.php
@@ -2,7 +2,7 @@
 
 namespace Unidays;
 
-class WhenConstructingWithoutACurrencyTest extends \PHPUnit_Framework_TestCase
+class WhenConstructingWithoutACurrencyTest extends TestCaseBase
 {
     /**
      * @test

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithoutACurrencyTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithoutACurrencyTest.php
@@ -8,11 +8,11 @@ class WhenConstructingWithoutACurrencyTest extends TestCaseBase
      * @test
      *
      * @dataProvider invalidInputs
-     *
-     * @expectedException InvalidArgumentException
      */
     public function ThenAnArgumentExceptionIsThrown($currency)
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $details = new DirectTrackingDetailsBuilder("somePartnerId", "Order123", $currency);
         $builtDetails = $details->build();
 

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithoutATransactionIdTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithoutATransactionIdTest.php
@@ -2,7 +2,7 @@
 
 namespace Unidays;
 
-class WhenConstructingWithoutATransactionIdTest extends \PHPUnit_Framework_TestCase
+class WhenConstructingWithoutATransactionIdTest extends TestCaseBase
 {
     /**
      * @test

--- a/test/Unidays/TrackingHelperTests/WhenConstructingWithoutATransactionIdTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenConstructingWithoutATransactionIdTest.php
@@ -8,11 +8,11 @@ class WhenConstructingWithoutATransactionIdTest extends TestCaseBase
      * @test
      *
      * @dataProvider invalidInputs
-     *
-     * @expectedException InvalidArgumentException
      */
     public function ThenAnArgumentExceptionIsThrown($transactionId)
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $details = new DirectTrackingDetailsBuilder("somePartnerId", $transactionId, "GBP");
         $builtDetails = $details->build();
 

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithAllParamsSetTest.php
@@ -2,11 +2,11 @@
 
 namespace Unidays;
 
-class WhenRequestingAScriptUrlWithAllParamsSetTest extends \PHPUnit_Framework_TestCase
+class WhenRequestingAScriptUrlWithAllParamsSetTest extends TestCaseBase
 {
     var $url;
 
-    public function setUp()
+    public function initialise()
     {
         $details = new DirectTrackingDetailsBuilder('somePartnerId', 'order123', 'GBP');
         $details->withOrderTotal(209.00);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithSomeParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithSomeParamsSetTest.php
@@ -2,11 +2,11 @@
 
 namespace Unidays;
 
-class WhenRequestingAScriptUrlWithSomeParamsSetTest extends \PHPUnit_Framework_TestCase
+class WhenRequestingAScriptUrlWithSomeParamsSetTest extends TestCaseBase
 {
     var $url;
 
-    public function setUp()
+    public function initialise()
     {
         $details = new DirectTrackingDetailsBuilder('somePartnerId', 'order123', 'GBP');
         $builtDetails = $details->build();

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithTestModeSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithTestModeSetTest.php
@@ -2,11 +2,11 @@
 
 namespace Unidays;
 
-class WhenRequestingAScriptUrlWithTestModeSetTest extends \PHPUnit_Framework_TestCase
+class WhenRequestingAScriptUrlWithTestModeSetTest extends TestCaseBase
 {
     var $url;
 
-    public function setUp()
+    public function initialise()
     {
         $details = new DirectTrackingDetailsBuilder('somePartnerId', 'order123', 'GBP');
         $details->withOrderTotal(209.00);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithAllParamsSetTest.php
@@ -2,11 +2,11 @@
 
 namespace Unidays;
 
-class WhenRequestingAServerUrlWithAllParamsSetTest extends \PHPUnit_Framework_TestCase
+class WhenRequestingAServerUrlWithAllParamsSetTest extends TestCaseBase
 {
     var $url;
 
-    public function setUp()
+    public function initialise()
     {
         $details = new DirectTrackingDetailsBuilder('a partner Id', 'the transaction id', 'GBP');
         $details->withOrderTotal(209.00);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithSomeParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithSomeParamsSetTest.php
@@ -2,11 +2,11 @@
 
 namespace Unidays;
 
-class WhenRequestingAServerUrlWithSomeParamsSetTest extends \PHPUnit_Framework_TestCase
+class WhenRequestingAServerUrlWithSomeParamsSetTest extends TestCaseBase
 {
     var $url;
 
-    public function setUp()
+    public function initialise()
     {
         $details = new DirectTrackingDetailsBuilder('a partner', 'the transaction', 'GBP');
         $builtDetails = $details->build();

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithTestModeSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithTestModeSetTest.php
@@ -2,11 +2,11 @@
 
 namespace Unidays;
 
-class WhenRequestingAServerUrlWithTestModeSetTest extends \PHPUnit_Framework_TestCase
+class WhenRequestingAServerUrlWithTestModeSetTest extends TestCaseBase
 {
     var $url;
 
-    public function setUp()
+    public function initialise()
     {
         $details = new DirectTrackingDetailsBuilder('a partner Id', 'the transaction id', 'GBP');
         $details->withOrderTotal(209.00);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithAllParamsSetTest.php
@@ -2,11 +2,11 @@
 
 namespace Unidays;
 
-class WhenRequestingASignedScriptUrlWithAllParamsSetTest extends \PHPUnit_Framework_TestCase
+class WhenRequestingASignedScriptUrlWithAllParamsSetTest extends TestCaseBase
 {
     var $url;
 
-    public function setUp()
+    public function initialise()
     {
         $details = new DirectTrackingDetailsBuilder('a partner Id', 'the transaction id', 'GBP');
         $details->withOrderTotal(209.00);

--- a/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithTestModeSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithTestModeSetTest.php
@@ -2,11 +2,11 @@
 
 namespace Unidays;
 
-class WhenRequestingASignedScriptUrlWithTestModeSetTest extends \PHPUnit_Framework_TestCase
+class WhenRequestingASignedScriptUrlWithTestModeSetTest extends TestCaseBase
 {
     var $url;
 
-    public function setUp()
+    public function initialise()
     {
         $details = new DirectTrackingDetailsBuilder('a partner Id', 'the transaction', 'GBP');
         $details->withOrderTotal(209.00);

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once(__DIR__ . '/../vendor/autoload.php');
-
-// Backwards compatibility shim to support phpunit >= 6
-if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase'))
-    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+if (PHP_MAJOR_VERSION >= 7 && PHP_MINOR_VERSION > 1)
+    require_once(__DIR__ . '/Unidays/TestCaseBase.php');
+else
+    require_once(__DIR__ . '/Unidays/TestCaseBase5.php');


### PR DESCRIPTION
Build is not currently passing on PHP 7.2 with PHPUnit 8.

Adds a workaround to enable continued support of PHP runtimes <7.1 (7.0 and 5.6)

Dropped support to 5.3. Keeping the compatibility across the different versions has become too difficult. 