### PR TITLE
Remove comma formatting on numbers over 999.99

### DIFF
--- a/src/Unidays/tracking-helper.php
+++ b/src/Unidays/tracking-helper.php
@@ -98,7 +98,7 @@ class TrackingHelper
 
     private function url_encode_number($number)
     {
-        return urlencode(number_format($number, 2, '.', ','));
+        return urlencode(number_format($number, 2, '.', ''));
     }
 
     private function parse_boolean($bool)

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAScriptUrlWithAllParamsSetTest.php
@@ -15,7 +15,7 @@ class WhenRequestingAScriptUrlWithAllParamsSetTest extends TestCaseBase
         $details->withItemsTax(34.50);
         $details->withShippingGross(5.00);
         $details->withShippingDiscount(3.00);
-        $details->withItemsGross(230.00);
+        $details->withItemsGross(1000.00);
         $details->withItemsOtherDiscount(10.00);
         $details->withUnidaysDiscountPercentage(10.00);
         $details->withNewCustomer(true);
@@ -67,7 +67,7 @@ class WhenRequestingAScriptUrlWithAllParamsSetTest extends TestCaseBase
      *              ["ItemsTax", "34.50"]
      *              ["ShippingGross", "5.00"]
      *              ["ShippingDiscount", "3.00"]
-     *              ["ItemsGross", "230.00"]
+     *              ["ItemsGross", "1000.00"]
      *              ["ItemsOtherDiscount", "10.00"]
      *              ["UNiDAYSDiscountPercentage", "10.00"]
      *              ["NewCustomer", "True"]

--- a/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingAServerUrlWithAllParamsSetTest.php
@@ -15,7 +15,7 @@ class WhenRequestingAServerUrlWithAllParamsSetTest extends TestCaseBase
         $details->withItemsTax(34.50);
         $details->withShippingGross(5.00);
         $details->withShippingDiscount(3.00);
-        $details->withItemsGross(230.00);
+        $details->withItemsGross(1000.00);
         $details->withItemsOtherDiscount(10.00);
         $details->withUnidaysDiscountPercentage(10.00);
         $details->withNewCustomer(true);
@@ -69,11 +69,11 @@ class WhenRequestingAServerUrlWithAllParamsSetTest extends TestCaseBase
      *              ["ItemsTax", "34.50"]
      *              ["ShippingGross", "5.00"]
      *              ["ShippingDiscount", "3.00"]
-     *              ["ItemsGross", "230.00"]
+     *              ["ItemsGross", "1000.00"]
      *              ["ItemsOtherDiscount", "10.00"]
      *              ["UNiDAYSDiscountPercentage", "10.00"]
      *              ["NewCustomer", "True"]
-     *              ["Signature", "VsP++N2PQ7Jy/hH6wjkVcGRLRkqpyBFyZPCLW7u0UYuXiYvBlggi4SgCQ1GPs5mg3JswBYms8qTwRehFpWhhAg=="]
+     *              ["Signature", "fx9sLAiZC+a+dvUcOFNhu4Ja31EgaX17m99y/m5BjlKS3NCMBbMouNPJ7MZCHqIUN0x66yz1z3Q5OB57vT7cgQ=="]
      */
     public function TheParameterShouldBeCorrect($parameter, $result)
     {

--- a/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithAllParamsSetTest.php
+++ b/test/Unidays/TrackingHelperTests/WhenRequestingASignedScriptUrlWithAllParamsSetTest.php
@@ -15,7 +15,7 @@ class WhenRequestingASignedScriptUrlWithAllParamsSetTest extends TestCaseBase
         $details->withItemsTax(34.50);
         $details->withShippingGross(5.00);
         $details->withShippingDiscount(3.00);
-        $details->withItemsGross(230.00);
+        $details->withItemsGross(1000.00);
         $details->withItemsOtherDiscount(10.00);
         $details->withUnidaysDiscountPercentage(10.00);
         $details->withNewCustomer(true);
@@ -69,11 +69,11 @@ class WhenRequestingASignedScriptUrlWithAllParamsSetTest extends TestCaseBase
      *              ["ItemsTax", "34.50"]
      *              ["ShippingGross", "5.00"]
      *              ["ShippingDiscount", "3.00"]
-     *              ["ItemsGross", "230.00"]
+     *              ["ItemsGross", "1000.00"]
      *              ["ItemsOtherDiscount", "10.00"]
      *              ["UNiDAYSDiscountPercentage", "10.00"]
      *              ["NewCustomer", "True"]
-     *              ["Signature", "c6sNwe3kcvr3/NYH+661/37BSP1RFIgrJ2LJ5e3ETOTD0kPBb6gzqvR8uEhFEJaksfBxy9Ct/rrn9/8fH0tuQQ=="]
+     *              ["Signature", "CJUr1kkv/426vsLQPGYlrt08xhkQ20ySx7262oGxRFFWbr7190A5Obalm6D67A45efC/MJAkGQeUgQjzIWXbZA=="]
      */
     public function TheParameterShouldBeCorrect($parameter, $result)
     {


### PR DESCRIPTION
### Description of the Change

`number_format()` no longer includes a comma when formatting numbers over 999.99

### Benefits

Hashing will actually work

### Possible Drawbacks

Existing consumers of the package will need to pull the latest version which includes this change.

### Verification Process

Unit tests have been altered to test against the number formatting.